### PR TITLE
Diverse Bugfixes und kleine Änderungen

### DIFF
--- a/botutils/sheetsclient.py
+++ b/botutils/sheetsclient.py
@@ -67,15 +67,15 @@ class Cell:
 
     def translate(self, columns: int, rows: int):
         """
-        Translates the cell by the given number of columns and rows
+        Returns cell translated by the given number of columns and rows
 
         :param columns: number of columns the cell should be moved
         :param rows: number of rows the rows the cell should be moved
         :return: resulting cell
         """
-        self.column += columns
-        self.row += rows
-        return self
+        return Cell(column=self.column + columns,
+                    row=self.row + rows,
+                    grid=self.grid)
 
 
 class CellRange:
@@ -114,15 +114,16 @@ class CellRange:
 
     def translate(self, columns, rows):
         """
-        Translates the cell range by the given number of columns and rows
+        Returns cell range translated by the given number of columns and rows
 
         :param columns: number of columns the range should be moved
         :param rows: number of rows the rows the range should be moved
         :return: resulting cell range
         """
-        self.column += columns
-        self.row += rows
-        return self
+        return CellRange(start_cell=Cell(column=self.column + columns,
+                                         row=self.row + rows),
+                         width=self.width,
+                         height=self.height)
 
     def expand(self, top=0, bottom=0, left=0, right=0):
         if self.column <= left or self.row <= top or left + right <= -self.width or top + bottom <= -self.height:

--- a/botutils/sheetsclient.py
+++ b/botutils/sheetsclient.py
@@ -481,13 +481,18 @@ class Client(restclient.Client):
         elif sheet and range:
             sheet_id = self.get_sheet_id(sheet)
             if sheet_id:
-                request['range'] = {
-                    "sheetId": sheet_id,
-                    "startRowIndex": 0,
-                    "endRowIndex": 5,
-                    "startColumnIndex": 0,
-                    "endColumnIndex": 3
-                }
+                try:
+                    cell_range = CellRange.from_a1(range)
+                except ValueError:
+                    return None
+                else:
+                    request['range'] = {
+                        "sheetId": sheet_id,
+                        "startRowIndex": cell_range.row,
+                        "endRowIndex": cell_range.row + cell_range.height,
+                        "startColumnIndex": cell_range.column,
+                        "endColumnIndex": cell_range.column + cell_range.width
+                    }
             else:
                 return None
         elif sheet:

--- a/botutils/sheetsclient.py
+++ b/botutils/sheetsclient.py
@@ -126,15 +126,15 @@ class CellRange:
                          height=self.height)
 
     def expand(self, top=0, bottom=0, left=0, right=0):
+        """
+        Returns cell range expanded by the given amount in each direction
+        """
         if self.column <= left or self.row <= top or left + right <= -self.width or top + bottom <= -self.height:
             raise ValueError
         else:
-            self.column -= left
-            self.row -= top
-            self.width += left + right
-            self.height += top + bottom
-            return self
-
+            return CellRange(start_cell=Cell(column=self.column - left, row=self.row - top),
+                             width=self.width + left + right,
+                             height=self.height + top + bottom)
 
 def get_service():
     try:

--- a/lang/spaetzle.json
+++ b/lang/spaetzle.json
@@ -79,6 +79,7 @@
         "danny_no_users": "Tell me usernames, pls!",
         "danny_done": "{} now got the predictions of {}!",
         "danny_done_notfound": "{} now got the predictions of {}!\nThese users I cant remember: {}",
+        "danny_empty": "Sorry, but didnt you set the matches?!",
         "table_footer": "Yes this is live, gobo7793!"
     },
     "de": {
@@ -163,6 +164,7 @@
         "danny_no_users": "Trage mir Namen in die Config ein oder sagse mir ins Gesicht!",
         "danny_done": "{} hat nun die Tipps von {} erhalten!",
         "danny_done_notfound": "{} hat nun die Tipps von {} erhalten!\n{} kenne ich aber gar nicht.",
+        "danny_empty": "Ist der Spieltag noch nicht gesetzt oder warum finde ich nix? :face_with_raised_eyebrow:",
         "table_footer": "@gobo: möglicherweise live-stände"
     }
 }

--- a/lang/sport.json
+++ b/lang/sport.json
@@ -49,7 +49,7 @@
         "help_buli": "Aktuelle Livestände der Bundesliga",
         "description_buli": "Zeigt die aktuellen Stände der derzeit laufenden Bundesliga-Spiele.\nMit dem Zusatz 'all' werden auch anstehende und beendete Spiele angezeigt.",
         "help_fußball": "Aktuelle Livestände einer Liga",
-        "description_fußball": "Zeigt die aktuellen Stände der derzeit laufenden Spieler einer Liga an. Die Liga wird über den entsprechenden Liga-Shortcut der OpenLigaDB angegeben.\nMit dem Zusatz 'all' werden auch anstehende und beendete Spiele angezeigt.",
+        "description_fußball": "Zeigt die aktuellen Stände der derzeit laufenden Spieler einer Liga an. Die Liga wird über den entsprechenden Liga-Shortcut der OpenLigaDB angegeben.\nMit dem Zusatz 'all' werden auch anstehende und beendete Spiele angezeigt.\nAkzeptierte Ligen: {}",
         "help_matches": "Listet alle Spiele, die in den nächsten 24 Stunden beginnen.",
 
         "soccer_title": "Fußball - {} - Live",

--- a/plugins/numberGuessing.py
+++ b/plugins/numberGuessing.py
@@ -221,11 +221,14 @@ class NumberGuessing:
         self.min = 0
         self.max = 0
 
-    async def guess(self, msg, guess=0, arg1=None, arg2=None):
+    async def guess(self, msg, guess=None, arg1=None, arg2=None):
         self.msg = msg
         # logging.info("Gamemode: {}".format(self.gamemode))
         # logging.info("guess: {}, arg1: {}, arg2: {}".format(guess, arg1, arg2))
-        if guess == "start":
+        if guess is None:
+            await self.start()
+            return ReturnCode.CONTINUING
+        elif guess == "start":
             try:
                 if arg1 and arg2:
                     await self.start(int(arg1), int(arg2))

--- a/plugins/spaetzle/spaetzle.py
+++ b/plugins/spaetzle/spaetzle.py
@@ -837,6 +837,9 @@ class Plugin(BasePlugin, name="Spaetzle-Tippspiel"):
                     else:
                         data_ranges.append("Aktuell!{}".format(CellRange(cell, 2, 11).rangename()))
                 result = c.get_multiple(data_ranges, formatted=False)
+                if not result[0]:
+                    await ctx.send(Lang.lang(self, 'danny_empty'))
+                    return
                 matchday = result[0][0][0]
                 matches = result[0][2:]
                 preds = result[1:]

--- a/plugins/spaetzle/spaetzle.py
+++ b/plugins/spaetzle/spaetzle.py
@@ -417,7 +417,7 @@ class Plugin(BasePlugin, name="Spaetzle-Tippspiel"):
             participants = Storage().get(self)['participants']
             for leag, p in participants.items():
                 data["Aktuell!{}".format(Config().get(self)['predictions_ranges'][leag])] = [[num for elem in
-                                                                         [[user, None] for user in p] for num in elem]]
+                                                                                              [[user, None] for user in p] for num in elem]]
                 for match in matches:
                     row = []
                     for user in p:

--- a/plugins/spaetzle/spaetzle.py
+++ b/plugins/spaetzle/spaetzle.py
@@ -416,15 +416,16 @@ class Plugin(BasePlugin, name="Spaetzle-Tippspiel"):
             data = {}
             participants = Storage().get(self)['participants']
             for leag, p in participants.items():
-                data[leag] = [[num for elem in [[user, None] for user in p] for num in elem]]
+                data["Aktuell!{}".format(Config().get(self)['predictions_ranges'][leag])] = [[num for elem in
+                                                                         [[user, None] for user in p] for num in elem]]
                 for match in matches:
                     row = []
                     for user in p:
                         row.extend(predictions_by_user.get(user, {}).get(match, [None, None]))
-                    data[leag].append(row)
+                    data["Aktuell!{}".format(Config().get(self)['predictions_ranges'][leag])].append(row)
 
             # Updating cells
-            c.update("Aktuell!{}".format(Config().get(self)['predictions_range']), data, raw=False)
+            c.update_multiple(data, raw=False)
         await add_reaction(ctx.message, Lang.CMDSUCCESS)
 
     @spaetzle_set.command(name="archive", help="Archives the current matchday and clears the frontpage")

--- a/plugins/spaetzle/spaetzle.py
+++ b/plugins/spaetzle/spaetzle.py
@@ -445,11 +445,13 @@ class Plugin(BasePlugin, name="Spaetzle-Tippspiel"):
                     ranges.append("Aktuell!{}".format(r.rangename()))
                 clear = c.clear_multiple(ranges)
                 if clear:
-                    replace = c.find_and_replace(find="ST {}".format(int(Storage().get(self)['matchday']) - 1),
+                    replace = c.find_and_replace(find="ST {}".format(Storage().get(self)['matchday'] - 1),
                                                  replace="ST {}".format(Storage().get(self)['matchday']),
                                                  include_formulas=True, sheet="Aktuell",
                                                  range=Config().get(self)['findreplace_matchday_range'])
         if duplicate and clear and replace:
+            Storage().get(self)['matchday'] += 1
+            Storage().save(self)
             await add_reaction(ctx.message, Lang.CMDSUCCESS)
         else:
             await add_reaction(ctx.message, Lang.CMDERROR)

--- a/plugins/sport.py
+++ b/plugins/sport.py
@@ -73,7 +73,7 @@ class Plugin(BasePlugin, name="Sport"):
     async def tippspiel(self, ctx):
         await ctx.send(Lang.lang(self, 'tippspiel_output'))
 
-    @commands.command(name="fußball")
+    @commands.command(name="fußball", alias="fussball")
     async def soccer_livescores(self, ctx, league, allmatches=None):
         if league not in Config().get(self)['leagues']:
             await ctx.send(Lang.lang(self, 'league_not_found', ", ".join(Config().get(self)['leagues'])))

--- a/plugins/sport.py
+++ b/plugins/sport.py
@@ -25,6 +25,7 @@ class Plugin(BasePlugin, name="Sport"):
 
     def default_config(self):
         return {
+            'sport_chan': 0,
             'leagues': ["bl1", "bl2", "bl3", "uefanl"],
             'liveticker_leagues': ["bl1", "bl2"]
         }
@@ -154,6 +155,8 @@ class Plugin(BasePlugin, name="Sport"):
                 self.liveticker_regs[league].deregister()
             leag_reg, self.liveticker_regs[league] = self.bot.liveticker.register(league, self.live_goals, True)
             msg.append("{} - Next: {}".format(league, leag_reg.next_match()))
+        Config().get(self)['sport_chan'] = ctx.channel.id
+        Config().save(self)
         await add_reaction(ctx.message, Lang.CMDSUCCESS)
         await ctx.send("\n".join(msg))
 
@@ -165,7 +168,7 @@ class Plugin(BasePlugin, name="Sport"):
         await add_reaction(ctx.message, Lang.CMDSUCCESS)
 
     async def live_goals(self, new_goals):
-        sport = Config().bot.get_channel(self.bot.CHAN_IDS.get('sport', 0))
+        sport = Config().bot.get_channel(Config().get(self)['sport_chan'])
 
         matches_with_goals = [x for x in new_goals.values() if x['new_goals'] and not x['is_finished']]
         if matches_with_goals:
@@ -179,8 +182,8 @@ class Plugin(BasePlugin, name="Sport"):
                     if not minute:
                         minute = "?"
                     match_goals.append(
-                        "{}:{} *{}'* {}".format(goal.get('ScoreTeam1', "?"), goal.get('ScoreTeam2', "?"),
-                                                minute, goal.get('GoalGetterName', "-")))
+                        "{}:{} {} ({}.)".format(goal.get('ScoreTeam1', "?"), goal.get('ScoreTeam2', "?"),
+                                                goal.get('GoalGetterName', "-"), minute))
                 match_msgs.append(" / ".join(match_goals))
             msgs = paginate(match_msgs, prefix=Lang.lang(self, 'liveticker_prefix'))
             for msg in msgs:


### PR DESCRIPTION
### Spätzle
- `set extract` gefixt
- `danny` gefixt, wenn Spieltag leer

### Sheetsclient
- translate und expand-Funktionen von Cell/CellRange geben die geänderte Cell bzw CellRange nur zurück, lassen das eigentliche Objekt unberührt
- find_and_replace-Request funktioniert nun auch mit angebbarer Range!

### Sport
- Sport-Channel-ID wird beim `!liveticker`-cmd gespeichert, statt in der bot-config
- `!fussball` als Alias für die Feinde des ß
- `!fußball` listet alle erlaubten Ligen in der Help-Description auf
- `!fußball` nimmt nun auch Aliase für die Ligennamen an (zB. '3fl' für bl3), konfigurierbar!

### NumberGuessing
`!guess` ohne weitere Angaben startet nun auch ein Spiel, wenn noch keines läuft